### PR TITLE
new translation of german

### DIFF
--- a/StrengthValidator.php
+++ b/StrengthValidator.php
@@ -306,7 +306,7 @@ class StrengthValidator extends \yii\validators\Validator
 
         foreach (self::$_rules as $rule => $setup) {
             $param = "{$rule}Error";
-            if ($rule === self::RULE_USER && $this->hasUser && !empty($value) && !empty($username) && strpos($value, $username) > 0) {
+            if ($rule === self::RULE_USER && $this->hasUser && !empty($value) && !empty($username) && strpos($value, $username) !== false) {
                 $this->addError($model, $attribute, $this->$param, ['attribute' => $label]);
             } elseif ($rule === self::RULE_EMAIL && $this->hasEmail && preg_match($setup['match'], $value, $matches)) {
                 $this->addError($model, $attribute, $this->$param, ['attribute' => $label]);

--- a/messages/de/kvpwdstrength.php
+++ b/messages/de/kvpwdstrength.php
@@ -17,21 +17,41 @@
  * NOTE: this file must be saved in UTF-8 encoding.
  */
 return [
-    '{attribute} should contain at least {n} {chars}, plural, one{one character} other{# characters}} ({found} found)!' =>
-        '{attribute} sollte mindestens {n, plural, one{ein Zeichen} other{# Zeichen}} ({found} gefunden)!',
+   <?php
+
+/**
+ * Message translations for \kartik\password\StrengthValidator.
+ *
+ * It contains the localizable messages extracted from source code.
+ * You may modify this file by translating the extracted messages.
+ *
+ * Each array element represents the translation (value) of a message (key).
+ * If the value is empty, the message is considered as not translated.
+ * Messages that no longer need translation will have their translations
+ * enclosed between a pair of '@@' marks.
+ *
+ * Message string can be used with plural forms format. Check i18n section
+ * of the guide for details.
+ *
+ * NOTE: this file must be saved in UTF-8 encoding.
+ */
+return [
+    '{attribute} should contain at least {n, plural, one{one character} other{# characters}} ({found} found)!' =>
+    '{attribute} muss mindestens {n, plural, one{ein Zeichen} other{# Zeichen}} enthalten ({found} gefunden)!',
     '{attribute} should contain at most {n, plural, one{one character} other{# characters}} ({found} found)!' =>
-        '{attribute} sollte höchstens {n, plural, one{ein Zeichen} other{# Zeichen}} ({found} gefunden)!',
+    '{attribute} darf höchstens {n, plural, one{ein Zeichen} other{# Zeichen}} enthalten ({found} gefunden)!',
     '{attribute} should contain exactly {n, plural, one{one character} other{# characters}} ({found} found)!' =>
-        '{attribute} sollte genau {n, plural, one{ein Zeichen} other{# Zeichen}} ({found} gefunden)!',
-    '{attribute} cannot contain the username' => '{attribute} nicht den Benutzernamen enthalten',
-    '{attribute} cannot contain an email address' => '{attribute} nicht die E-Mail-Adresse enthalten',
-    '{attribute} must be a string' => '{attribute} muss ein String sein',
+    '{attribute} muss genau {n, plural, one{ein Zeichen} other{# Zeichen}} enthalten ({found} gefunden)!',
+    '{attribute} cannot contain the username' => '{attribute} darf den Benutzernamen enthalten',
+    '{attribute} cannot contain an email address' => '{attribute} darf nicht die E-Mail-Adresse enthalten',
+    '{attribute} must be a string' => '{attribute} muss eine Zeichenfogle sein',
     '{attribute} should contain at least {n, plural, one{one lower case character} other{# lower case characters}} ({found} found)!' =>
-        '{attribute} sollte mindestens {n, plural, one{ein Kleinbuchstaben enthalten} other{# Kleinbuchstaben enthalten}} ({found} gefunden)!',
+        '{attribute} muss mindestens {n, plural, one{ein Kleinbuchstaben enthalten} other{# Kleinbuchstaben enthalten}} ({found} gefunden)!',
     '{attribute} should contain at least {n, plural, one{one upper case character} other{# upper case characters}} ({found} found)!' =>
-        '{attribute} sollte mindestens {n, plural, one{ein Großbuchstaben enthalten} other{# Großbuchstaben enthalten}} ({found} gefunden)!',
+        '{attribute} muss mindestens {n, plural, one{ein Großbuchstaben enthalten} other{# Großbuchstaben enthalten}} ({found} gefunden)!',
     '{attribute} should contain at least {n, plural, one{one numeric / digit character} other{# numeric / digit characters}} ({found} found)!' =>
-        '{attribute} sollte mindestens {n, plural, one{numerisch / stelligen Zeichen enthalten} other{# numerisch / stelligen Zeichen enthalten}} ({found} gefunden)!',
+        '{attribute} muss mindestens {n, plural, one{eine Ziffer enthalten} other{# Ziffern enthalten}} ({found} gefunden)!',
     '{attribute} should contain at least {n, plural, one{one special character} other{# special characters}} ({found} found)!' =>
-        '{attribute} sollte mindestens {n, plural, one{ein Sonderzeichen enthalten} other{# Sonderzeichen enthalten}} ({found} gefunden)!',
+        '{attribute} muss mindestens {n, plural, one{ein Sonderzeichen enthalten} other{# Sonderzeichen enthalten}} ({found} gefunden)!',
+];
 ];

--- a/messages/de/kvpwdstrength.php
+++ b/messages/de/kvpwdstrength.php
@@ -42,7 +42,7 @@ return [
     '{attribute} darf höchstens {n, plural, one{ein Zeichen} other{# Zeichen}} enthalten ({found} gefunden)!',
     '{attribute} should contain exactly {n, plural, one{one character} other{# characters}} ({found} found)!' =>
     '{attribute} muss genau {n, plural, one{ein Zeichen} other{# Zeichen}} enthalten ({found} gefunden)!',
-    '{attribute} cannot contain the username' => '{attribute} darf den Benutzernamen enthalten',
+    '{attribute} cannot contain the username' => '{attribute} darf den Benutzernamen nicht enthalten',
     '{attribute} cannot contain an email address' => '{attribute} darf nicht die E-Mail-Adresse enthalten',
     '{attribute} must be a string' => '{attribute} muss eine Zeichenfogle sein',
     '{attribute} should contain at least {n, plural, one{one lower case character} other{# lower case characters}} ({found} found)!' =>

--- a/messages/de/kvpwdstrength.php
+++ b/messages/de/kvpwdstrength.php
@@ -43,7 +43,7 @@ return [
     '{attribute} should contain exactly {n, plural, one{one character} other{# characters}} ({found} found)!' =>
     '{attribute} muss genau {n, plural, one{ein Zeichen} other{# Zeichen}} enthalten ({found} gefunden)!',
     '{attribute} cannot contain the username' => '{attribute} darf den Benutzernamen nicht enthalten',
-    '{attribute} cannot contain an email address' => '{attribute} darf nicht die E-Mail-Adresse enthalten',
+    '{attribute} cannot contain an email address' => '{attribute} darf keine E-Mail-Adresse enthalten',
     '{attribute} must be a string' => '{attribute} muss eine Zeichenfogle sein',
     '{attribute} should contain at least {n, plural, one{one lower case character} other{# lower case characters}} ({found} found)!' =>
         '{attribute} muss mindestens {n, plural, one{ein Kleinbuchstaben enthalten} other{# Kleinbuchstaben enthalten}} ({found} gefunden)!',


### PR DESCRIPTION
I have improved the German Translation.
And added a Bugffix:
If pasword and username were identical no error message was thrown. 
error was: 
stropos ($value,$username) >0 insetad of stropos ($value,$username) !== false