### PR TITLE
Fix for short-long language code conflict

### DIFF
--- a/PasswordInput.php
+++ b/PasswordInput.php
@@ -93,10 +93,10 @@ class PasswordInput extends \kartik\base\InputWidget
     public function registerAssets()
     {
         $view = $this->getView();
-        $locale = "js/locales/strength-meter-{$this->language}.js";
-        $path = Yii::getAlias("@vendor/kartik-v/strength-meter/{$locale}");
-        if (!empty($this->language) && file_exists($path)) {
-            PasswordInputAsset::register($view)->js[] = $locale;
+        $path = Yii::getAlias("@vendor/kartik-v/strength-meter");
+        $this->setLanguage('strength-meter-', $path, 'js/locales');
+        if (!empty($this->_langFile)) {
+            PasswordInputAsset::register($view)->js[] = $this->_langFile;
         } else {
             PasswordInputAsset::register($view);
         }


### PR DESCRIPTION
Old implementation uses `$this->language`, which contains always the full language code set in application config. So, it works only if I have exactly the same code in my localized `strength-meter-xx.js`.

If I set long language code in application config (i.e. `hu-HU`) and make the strength meter locale file with short language code (i.e. `hu`), it won't find it.

For example, assume that `hu-HU` is set as language in application config. Even if I have `strength-meter-hu.js` or `strength-meter-hu-HU.js` for hungarian language, it works with the new implementation.

Now it uses the `setLanguage` function implemented in `InputWidget`.