### PR TITLE
Model is required to have a username attribute (or userAttribute)

### DIFF
--- a/StrengthValidator.php
+++ b/StrengthValidator.php
@@ -301,7 +301,7 @@ class StrengthValidator extends \yii\validators\Validator
             return;
         }
         $label = $model->getAttributeLabel($attribute);
-        $username = Html::getAttributeValue($model, $this->userAttribute);
+        $username = $this->hasUser ? Html::getAttributeValue($model, $this->userAttribute) : '';
         $temp = [];
 
         foreach (self::$_rules as $rule => $setup) {


### PR DESCRIPTION
I have a password reset form model that doesn't have a username attribute. I thought simply setting hasUser => false would bypass the username check, but I get the following exception:

```
Getting unknown property: app\models\user\PasswordForm::username
```

It's related to fetching the username from the model, regardless of if it will be used, on line 304 of StrengthValidator.php:

```
$username = Html::getAttributeValue($model, $this->userAttribute);
```

I'm not sure if my solution to this problem in this pull request is the right answer, but it seems to work for my use case.