### PR TITLE
Add support to check password in haveibeenpwned.com online lists

### DIFF
--- a/src/presets.php
+++ b/src/presets.php
@@ -18,6 +18,7 @@ return [
         'special' => 0,
         'hasUser' => false,
         'hasEmail' => false,
+        'checkHaveIBeenPwned' => true,
     ],
     StrengthValidator::NORMAL => [
         'min' => 8,
@@ -27,6 +28,7 @@ return [
         'special' => 0,
         'hasUser' => true,
         'hasEmail' => true,
+        'checkHaveIBeenPwned' => true,
     ],
     StrengthValidator::FAIR => [
         'min' => 10,
@@ -36,6 +38,7 @@ return [
         'special' => 1,
         'hasUser' => true,
         'hasEmail' => true,
+        'checkHaveIBeenPwned' => true,
     ],
     StrengthValidator::MEDIUM => [
         'min' => 10,
@@ -45,6 +48,7 @@ return [
         'special' => 1,
         'hasUser' => true,
         'hasEmail' => true,
+        'checkHaveIBeenPwned' => true,
     ],
     StrengthValidator::STRONG => [
         'min' => 12,
@@ -54,5 +58,6 @@ return [
         'special' => 2,
         'hasUser' => true,
         'hasEmail' => true,
+        'checkHaveIBeenPwned' => true,
     ],
 ];


### PR DESCRIPTION
I have added a new check which will check the password against the Have I Been Pwned database (https://haveibeenpwned.com/). Only the first 5 characters of the hash are provided to the online service. see https://haveibeenpwned.com/API/v3#SearchingPwnedPasswordsByRange
